### PR TITLE
Removed XQuartz installation

### DIFF
--- a/Mozart_Programming_Interface.app/Contents/MacOS/build.py
+++ b/Mozart_Programming_Interface.app/Contents/MacOS/build.py
@@ -28,6 +28,8 @@ import sys, os, subprocess, argparse
 description = "Build and deploy the Mozart 1.4.0 container."
 # User home directory path
 user_path = os.path.expanduser("~")
+# Parent directory of this script
+parent_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 #############
@@ -247,22 +249,11 @@ subprocess.run(command, shell=True)
 
 # Background script to make the Mozart window visible when started
 # This script will toggle fullscreen on and off on the Mozart window.
-script = """#!/bin/zsh
-number=$(wmctrl -l | wc -l)
-while [[ $(wmctrl -l | wc -l) -eq $number ]] do
-continue
-done
-win=$(wmctrl -l | sed -n $((number+1))p | cut -d' ' -f4)
-wmctrl -r $win -b add,fullscreen
-wmctrl -r $win -b remove,fullscreen
-"""
-# Write script into a temporary file
-with open(f"{user_path}/script_temp.sh", "w") as file:
-    file.writelines(script)
+display_script = f"{parent_dir}/display_window.sh"
 # Make the script file executable
-subprocess.run(f"chmod +x {user_path}/script_temp.sh", shell=True)
+subprocess.run(f"chmod +x {display_script}", shell=True)
 # Run the script in background
-subprocess.Popen(f"{user_path}/script_temp.sh", shell=True)
+subprocess.Popen(f"{display_script}", shell=True)
 
 # Indicate argument configuration to the user
 print(f"Running instance {instance} of the container.")
@@ -300,8 +291,6 @@ command = f"docker ps -aq -f ancestor={image}"
 output = subprocess.run(command, shell=True, stdout=subprocess.PIPE).stdout
 if not output:
     # Output of command is empty, all the instances have been stopped
-    # Remove the temporary script used to make the Mozart window visible when started
-    os.remove(f"{user_path}/script_temp.sh")
     # Remove IP address from the addresses accepted by XQuartz
     command = f"xhost -{ip}"
     subprocess.run(command, shell=True)

--- a/Mozart_Programming_Interface.app/Contents/MacOS/build.py
+++ b/Mozart_Programming_Interface.app/Contents/MacOS/build.py
@@ -200,13 +200,6 @@ if not install_ok:
     # Installation failed, exit
     exit(-1)
 
-# XQuartz, a X11 server for MacOS
-# Install XQuartz if not already installed, and check installation
-install_ok = check_and_install_package("xquartz")
-if not install_ok:
-    # Installation failed, exit
-    exit(-1)
-
 # wmctrl, a tool to interact with GUI windows
 # Install wmctrl if not already installed, and check installation
 install_ok = check_and_install_package("wmctrl")

--- a/Mozart_Programming_Interface.app/Contents/MacOS/display_window.sh
+++ b/Mozart_Programming_Interface.app/Contents/MacOS/display_window.sh
@@ -1,0 +1,24 @@
+#!/bin/zsh
+
+# Zsh script to make the Mozart window visible when started,
+# by toggling fullscreen on and off on the Mozart window.
+# This script should not be run alone, and should only
+# be called by the Python script `display_window.sh`.
+#
+# Authors: DEFRERE Sacha, DE KEERSMAEKER Francois, KUPERBLUM Jeremie
+
+# Initial number of windows on screen
+number=$(wmctrl -l | wc -l)
+
+# Loop while there is no new window
+while [[ $(wmctrl -l | wc -l) -eq $number ]] do
+    continue
+done
+# End of loop, a new window appeared, which is the Mozart window
+
+# Get the identifier of the Mozart window
+win=$(wmctrl -l | sed -n $((number+1))p | cut -d' ' -f4)
+
+# Toggle fullscreen on and off
+wmctrl -r $win -b add,fullscreen
+wmctrl -r $win -b remove,fullscreen

--- a/README.md
+++ b/README.md
@@ -24,10 +24,16 @@ To use the Docker container, Docker must be installed on the computer.
 To this end, please visit [Docker's installation instructions for MacOS](https://docs.docker.com/desktop/mac/install/).
 
 Additionally, to run the script to build and deploy the container,
-Python must be installed.
+Python version 3 or above must be installed.
 Please follow the instructions on the [Python website](https://www.python.org/downloads/).
 If you have [Xcode](https://developer.apple.com/xcode/) installed,
 Python is already included.
+
+Finally, to allow the Mozart 1.4.0 to be used with its Graphical User Interface (GUI),
+a [X11](https://en.wikipedia.org/wiki/X_Window_System) server must be installed.
+Please install [XQuartz](https://www.xquartz.org/),
+a X11 server for MacOS, by downloading it from
+https://www.xquartz.org/.
 
 ### Use the container
 
@@ -61,14 +67,6 @@ By default, this directory is found at the path `~/Desktop/oz-files` on the host
 To exit the Mozart 1.4.0 container, exit the Mozart window, and type
 `exit`, or `CTRL+D` inside the container terminal.
 
-Note: Additional necessary tools are installed when the container is launched:
-- [Homebrew](https://brew.sh/index_fr), a package manager to install other software
-- `socat`, a tool to forward sockets
-- A [X11](https://en.wikipedia.org/wiki/X_Window_System) server for MacOS,
-    [XQuartz](https://www.xquartz.org/),
-    that provides GUI capabilities to applications inside containers.
-- `wmctrl`, a tool to manage the GUI windows
-
 
 ## Customization and troubleshooting
 
@@ -87,9 +85,8 @@ and inspect the files of the application.
 Go to `Mozart_Programming_Interface.app/Contents/MacOS`,
 and run the script with the following command:
 ```shell
-$ python build.py [-d SHARED_DIR_HOST] [-n INSTANCE_NAME] [-p PORT_MAPPING]
+$ python3 build.py [-d SHARED_DIR_HOST] [-n INSTANCE_NAME] [-p PORT_MAPPING]
 ```
-(or `python3`, `py`, ... instead of `python` to suit your python command)
 
 The `-d` option allows to provide the path of a host directory
 that will be shared with the container.


### PR DESCRIPTION
XQuartz is not installed with the script anymore.
The user is asked in the prerequisites to download and install it before.
(Additionally, the background script to make the Mozart window visible is now separated)